### PR TITLE
feat: add Confidence Method Explanation route and link in LineConfidenceViz

### DIFF
--- a/src/app/Sensor/_Router/Router.tsx
+++ b/src/app/Sensor/_Router/Router.tsx
@@ -3,6 +3,7 @@ import { Route, Switch, RouteComponentProps } from 'react-router-dom';
 import HeatMapViz from '../../Sensor/viz/HeatMapViz';
 import ScatterTimeViz from '../../Sensor/viz/ScatterTimeViz';
 import LineConfidenceViz from '../viz/LineConfidenceViz/LineConfidenceViz';
+import { ConfidenceMethodExplanation } from '../viz';
 import SensorDashboard from '../../SensorDashboard/SensorDashboard';
 const Router: React.FC = () => {
   return (
@@ -79,6 +80,11 @@ const Router: React.FC = () => {
             sensorId={sensorId}
           />
         )}
+      />
+      <Route
+        exact
+        path={`/docs/confidence-explanation`}
+        component={ConfidenceMethodExplanation}
       />
     </Switch>
   );

--- a/src/app/Sensor/viz/ConfidenceMethodExplanation.tsx
+++ b/src/app/Sensor/viz/ConfidenceMethodExplanation.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+
+const ConfidenceMethodExplanation: React.FC = () => {
+  return (
+    <div className="max-w-4xl mx-auto p-6 bg-white rounded-lg shadow-md">
+      <h1 className="text-3xl font-bold mb-6 text-primary-800">
+        Understanding Confidence Intervals in Sensor Data Visualization
+      </h1>
+
+      <section className="mb-8">
+        <h2 className="text-2xl font-semibold mb-4 text-primary-700">
+          What are Confidence Intervals?
+        </h2>
+        <p className="mb-4">
+          Confidence intervals represent the reliability of an estimate. When
+          visualizing sensor measurements, confidence intervals help you
+          understand the reliability of the average (mean) value displayed. The
+          LineConfidenceViz component shows these intervals as shaded areas
+          around the main line.
+        </p>
+        <p className="mb-4">
+          All confidence intervals displayed in the visualization represent a
+          95% confidence level, meaning we can be 95% confident that the true
+          value falls within the displayed range.
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-2xl font-semibold mb-4 text-primary-700">
+          Types of Confidence Intervals
+        </h2>
+        <p className="mb-4">
+          The visualization uses two complementary methods to calculate
+          confidence intervals:
+        </p>
+
+        <div className="bg-gray-50 p-4 rounded-lg mb-6">
+          <h3 className="text-xl font-medium mb-2 text-primary-600">
+            1. Percentile-based Intervals
+          </h3>
+          <p className="mb-2">
+            These are displayed as{' '}
+            <span className="font-semibold">lower_bound</span> and{' '}
+            <span className="font-semibold">upper_bound</span> in the data.
+          </p>
+          <ul className="list-disc pl-6 mb-2">
+            <li>Based on the actual distribution of data points</li>
+            <li>Lower bound corresponds to the 2.5th percentile</li>
+            <li>Upper bound corresponds to the 97.5th percentile</li>
+            <li>Reflects the spread of actual measurements</li>
+          </ul>
+          <p>
+            These intervals make no assumptions about the data distribution and
+            are purely based on the observed values.
+          </p>
+        </div>
+
+        <div className="bg-gray-50 p-4 rounded-lg">
+          <h3 className="text-xl font-medium mb-2 text-primary-600">
+            2. Parametric Intervals
+          </h3>
+          <p className="mb-2">
+            These are displayed as{' '}
+            <span className="font-semibold">parametric_lower_bound</span> and{' '}
+            <span className="font-semibold">parametric_upper_bound</span> in the
+            data.
+          </p>
+          <ul className="list-disc pl-6 mb-2">
+            <li>Calculated using statistical theory and the t-distribution</li>
+            <li>Adapts to the sample size for better accuracy</li>
+            <li>Formula: mean ± (t-value × standard error)</li>
+          </ul>
+          <p className="mb-2">
+            The multiplier (t-value) adjusts based on the number of data points:
+          </p>
+          <table className="w-full border-collapse border border-gray-300 mb-2">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="border border-gray-300 p-2">Sample Size</th>
+                <th className="border border-gray-300 p-2">t-value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="border border-gray-300 p-2">30+ data points</td>
+                <td className="border border-gray-300 p-2">
+                  1.96 (normal distribution)
+                </td>
+              </tr>
+              <tr>
+                <td className="border border-gray-300 p-2">
+                  20-29 data points
+                </td>
+                <td className="border border-gray-300 p-2">2.09</td>
+              </tr>
+              <tr>
+                <td className="border border-gray-300 p-2">
+                  10-19 data points
+                </td>
+                <td className="border border-gray-300 p-2">2.23</td>
+              </tr>
+              <tr>
+                <td className="border border-gray-300 p-2">
+                  Fewer than 10 points
+                </td>
+                <td className="border border-gray-300 p-2">2.58</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            These intervals assume the data follows a normal distribution and
+            are more appropriate when this assumption holds.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ConfidenceMethodExplanation;

--- a/src/app/Sensor/viz/LineConfidenceViz/LineConfidenceViz.tsx
+++ b/src/app/Sensor/viz/LineConfidenceViz/LineConfidenceViz.tsx
@@ -4,6 +4,8 @@ import { Chart } from './_components/Chart';
 import { selectAggregationInterval } from '../../../../utils/aggregationProcessing';
 import QueryWrapper from '../../../common/QueryWrapper';
 import MeasurementSummary from '../../../SensorDashboard/_components/MeasurementSummary';
+import { Link } from 'react-router-dom';
+
 type AggregationInterval =
   | 'second'
   | 'minute'
@@ -65,24 +67,44 @@ const LineConfidenceViz = ({
   return (
     <QueryWrapper isLoading={isLoading} error={error}>
       {data && (
-        <div className="flex flex-col items-center  h-screen">
+        <div className="flex flex-col items-center h-screen">
           <MeasurementSummary data={data} />
-          <div className="mb-4">
-            <label htmlFor="aggregationInterval" className="mr-2">
-              Aggregation Interval:
-            </label>
-            <select
-              id="aggregationInterval"
-              value={aggregationInterval || ''}
-              onChange={handleAggregationIntervalChange}
-              className="p-2 border rounded"
+          <div className="mb-4 flex items-center justify-between w-full max-w-4xl">
+            <div className="flex items-center">
+              <label htmlFor="aggregationInterval" className="mr-2">
+                Aggregation Interval:
+              </label>
+              <select
+                id="aggregationInterval"
+                value={aggregationInterval || ''}
+                onChange={handleAggregationIntervalChange}
+                className="p-2 border rounded"
+              >
+                {AGGREGATION_INTERVALS.map((interval) => (
+                  <option key={interval} value={interval}>
+                    {interval.charAt(0).toUpperCase() + interval.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <Link
+              to={`/sensor/confidence-explanation`}
+              className="text-indigo-600 hover:text-indigo-800 flex items-center"
             >
-              {AGGREGATION_INTERVALS.map((interval) => (
-                <option key={interval} value={interval}>
-                  {interval.charAt(0).toUpperCase() + interval.slice(1)}
-                </option>
-              ))}
-            </select>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5 mr-1"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              About Confidence Intervals
+            </Link>
           </div>
 
           {aggregationInterval && (

--- a/src/app/Sensor/viz/index.ts
+++ b/src/app/Sensor/viz/index.ts
@@ -1,0 +1,5 @@
+export { default as LineConfidenceViz } from './LineConfidenceViz';
+export { default as HeatMapViz } from './HeatMapViz';
+export { default as ScatterTimeViz } from './ScatterTimeViz';
+export { default as RouteMapViz } from './RouteMapViz';
+export { default as ConfidenceMethodExplanation } from './ConfidenceMethodExplanation';

--- a/src/app/_Router/_Router.tsx
+++ b/src/app/_Router/_Router.tsx
@@ -6,7 +6,7 @@ import ProtectedRoute from '../common/ProtectedRoute';
 import Login from '../Login/Login';
 import { useAuth } from '../../contexts/AuthContext';
 import { Loading } from '../common/Loading';
-
+import ConfidenceMethodExplanation from '../Sensor/viz/ConfidenceMethodExplanation';
 const Router: React.FC = () => {
   const { isAuthenticated, isLoading } = useAuth();
   if (isLoading) {
@@ -23,6 +23,12 @@ const Router: React.FC = () => {
       </ProtectedRoute>
       <ProtectedRoute isAuthenticated={isAuthenticated} path="/campaigns">
         <Campaign />
+      </ProtectedRoute>
+      <ProtectedRoute
+        isAuthenticated={isAuthenticated}
+        path="/docs/confidence-explanation"
+      >
+        <ConfidenceMethodExplanation />
       </ProtectedRoute>
     </Switch>
   );


### PR DESCRIPTION
- Introduced a new route for the ConfidenceMethodExplanation component in the main Router.
- Added a link in the LineConfidenceViz component to navigate to the Confidence Method Explanation, enhancing user access to information about confidence intervals.
- Updated layout in LineConfidenceViz for improved responsiveness and user experience.
